### PR TITLE
Add installation steps and trim TODO list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Byte-compiled files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+venv/
+env/
+
+# Distribution artifacts
+build/
+dist/
+*.egg-info/
+
+# Logs
+*.log
+
+# Generated output
+output/
+downloads/
+
+# OS files
+.DS_Store
+
+# Temporary files
+*.tmp
+*.temp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Contribution Guide for Agents
+
+TranscribeMonkey is a Tkinter-based desktop app for downloading, transcribing,
+and optionally translating audio files. Automated contributors should adhere to
+the following conventions.
+
+## Style
+- Follow **PEP 8** with 4‑space indentation and `lower_snake_case` for
+  functions.
+- Provide docstrings for public classes and functions.
+- Add any third‑party packages to `requirements.txt`.
+
+## Repository Layout
+- All source modules live in the repository root; avoid new directories unless
+  absolutely necessary.
+- Do **not** commit generated content such as `output/`, `downloads/` or
+  `__pycache__/`.
+- GUI logic stays in `gui.py`; download/transcribe/translate logic remains in
+  their respective modules.
+
+## Required Checks
+Before committing run:
+
+```bash
+python -m py_compile *.py
+```
+
+All files must compile successfully. If additional tests are introduced, run
+those as well.
+
+## Commit Practices
+- Write concise commit messages.
+- Update `README.MD` when user-facing behavior changes.
+- Never commit API keys or personal settings.

--- a/README.MD
+++ b/README.MD
@@ -27,6 +27,28 @@ Dependencies include:
 - `openai-whisper` for transcription.
 - `googletrans` for translation.
 
+## Installation
+
+1. **Clone the repository**:
+
+   ```bash
+   git clone https://github.com/yourusername/TranscribeMonkey.git
+   cd TranscribeMonkey
+   ```
+
+2. **(Optional) Create a virtual environment**:
+
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+
+3. **Install dependencies**:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
 ## Setup
 
 1. **Configure Settings**: Modify `settings.json` as needed. You can find an example [here](settings_example.json) or refer to the snippet below, e.g., `"chunk_length": 30` to set the audio chunk length to 30 seconds:
@@ -92,19 +114,9 @@ A: Currently, the model download step is not reflected in the progress bar. This
 
 ## TODO
 
-### Transcription Enhancements
-- Implement batch processing to allow users to transcribe multiple files at once.
-- Add more customizable transcription settings, such as output formats and processing modes.
-- Add more advanced audio quality settings for finer control.
-
-### User Interface Improvements
-- Improve GUI layout for a more user-friendly experience.
-- Add model download progress to the progress bar.
-- Improve user feedback during processing for better responsiveness.
-
-### User Experience Features
-- Add error handling for network issues during YouTube download.
-- Implement a feature to pause and resume downloads.
-- Add a logging feature to keep a record of transcriptions and translations.
-- Create a detailed user manual with screenshots.
+- [ ] Batch transcription to process multiple files at once
+- [ ] Display Whisper model download progress in the GUI
+- [ ] Pause and resume downloads and transcriptions
+- [ ] Save a persistent log of completed tasks
+- [ ] Write a detailed user manual with screenshots
 


### PR DESCRIPTION
## Summary
- document repo cloning, optional venv setup, and dependency install
- condense TODO section to five top-level tasks

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_688384bd0c1c832ebb4d3fd29e715289