### PR TITLE
Add stop button and improved progress

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -10,6 +10,8 @@ TranscribeMonkey is a desktop application. It allows users to download, transcri
 - **Translation**: Translate transcriptions into various target languages using Google Translate.
 - **SRT Formatting**: Generates `.srt` subtitle files for compatibility with video players.
 - **Progress Display**: Displays progress for download, transcription, and translation tasks, including ETAs.
+- **Detailed Progress**: Shows chunk counts and translation progress for better feedback.
+- **Stop Button**: Cancel ongoing downloads or transcriptions safely.
 
 ## Requirements
 

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -19,8 +19,9 @@ class AudioConversionError(DownloaderError):
 class Downloader:
     """Utility class for downloading YouTube audio."""
 
-    def __init__(self, progress_callback=None):
+    def __init__(self, progress_callback=None, stop_event=None):
         self.progress_callback = progress_callback
+        self.stop_event = stop_event
 
     def get_ydl_opts(self, download_path, progress_hook):
         """Return yt-dlp options for downloading a single video's audio."""
@@ -57,6 +58,8 @@ class Downloader:
         
         # Define the progress hook function
         def progress_hook(d):
+            if self.stop_event and self.stop_event.is_set():
+                raise DownloaderError("Download stopped by user.")
             try:
                 if self.progress_callback:
                     self.progress_callback(d)

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -59,16 +59,22 @@ class Transcriber:
 
         return chunk_paths
 
-    def transcribe_chunks(self, chunk_paths, language=None, progress_callback=None):
-        """
-        Transcribes each audio chunk and detects language if set to automatic.
-        Returns a list of transcripts and the detected language code.
+    def transcribe_chunks(self, chunk_paths, language=None, progress_callback=None, stop_event=None):
+        """Transcribe a list of audio chunks.
+
+        :param chunk_paths: List of paths to audio chunks.
+        :param language: Language code or ``None`` for auto-detection.
+        :param progress_callback: Optional callback receiving progress percent, current chunk index, and total chunks.
+        :param stop_event: Optional ``threading.Event`` to stop processing.
+        :return: Tuple of transcripts list and detected language code.
         """
         transcripts = []
         detected_language = None
         total_chunks = len(chunk_paths)
 
         for idx, chunk in enumerate(chunk_paths):
+            if stop_event and stop_event.is_set():
+                break
             language_param = language  # Already set to None if automatic
 
             try:
@@ -84,7 +90,7 @@ class Transcriber:
 
                 # Update progress
                 if progress_callback:
-                    progress_callback((idx + 1) / total_chunks * 100)
+                    progress_callback((idx + 1) / total_chunks * 100, idx + 1, total_chunks)
 
             except Exception as e:
                 logger.error("Whisper transcription error: %s", e)


### PR DESCRIPTION
## Summary
- add stop button for cancellation
- allow Downloader and Transcriber to respect stop events
- show chunk and translation progress in GUI
- document new features in README

## Testing
- `python -m py_compile src/*.py main.py setup_env.py`
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6883c5f33088832e8267d088ac800c1c