### PR TITLE
Enable hardware acceleration for Whisper transcription

### DIFF
--- a/processor/transcriber.py
+++ b/processor/transcriber.py
@@ -13,7 +13,27 @@ logger = get_logger(__name__)
 os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'expandable_segments:True'
 
 class Transcriber:
-    """Handle audio conversion and transcription using Whisper."""
+    """Handle audio conversion and transcription using Whisper.
+
+    Notes
+    -----
+    Performance on Apple Silicon (M1/M2) is still maturing:
+
+    - Depending on your PyTorch and macOS versions, some Whisper models
+      may run **slower on MPS than on CPU**. Benchmark both backends and
+      choose the faster one for your setup.
+    - Upgrading to the latest releases of PyTorch and macOS usually
+      improves MPS stability and speed. See the PyTorch `mps` notes for
+      details.
+    - Adjust ``chunk_length`` in :meth:`split_audio` or the ``batch_size``
+      parameter of ``whisper.transcribe`` to trade memory usage for
+      throughput.
+
+    References
+    ----------
+    - Whisper performance: https://github.com/openai/whisper#performance
+    - PyTorch MPS documentation: https://pytorch.org/docs/stable/notes/mps.html
+    """
 
     def __init__(self, model_variant='base'):
         """Initialize the transcriber with hardware acceleration when possible."""

--- a/processor/translator.py
+++ b/processor/translator.py
@@ -1,19 +1,64 @@
 # translator.py
+import time
+
 from googletrans import Translator as GoogleTranslator
+from deep_translator import MyMemoryTranslator
 
 from src.logger import get_logger
 
 logger = get_logger(__name__)
 
+
 class Translator:
-    def __init__(self):
+    """Translate text with retries and a fallback provider."""
+
+    def __init__(self, retries=3, retry_delay=1.0):
+        """Initialize the translator.
+
+        Parameters
+        ----------
+        retries : int, optional
+            Number of attempts for the primary translator, by default ``3``.
+        retry_delay : float, optional
+            Seconds to wait between retries, by default ``1.0``.
+        """
         self.translator = GoogleTranslator()
+        self.retries = retries
+        self.retry_delay = retry_delay
 
     def translate_text(self, text, target_language='en'):
+        """Translate text to the target language with retry and fallback.
+
+        Parameters
+        ----------
+        text : str
+            Text to translate.
+        target_language : str, optional
+            Language code to translate into, by default ``'en'``.
+
+        Returns
+        -------
+        str
+            Translated text or the original text if all providers fail.
+        """
+        for attempt in range(1, self.retries + 1):
+            try:
+                translated = self.translator.translate(text, dest=target_language)
+                return translated.text
+            except Exception as e:
+                logger.error(
+                    "Translation attempt %d/%d failed: %s",
+                    attempt,
+                    self.retries,
+                    e,
+                )
+                time.sleep(self.retry_delay)
+
         try:
-            translated = self.translator.translate(text, dest=target_language)
-            return translated.text
+            return MyMemoryTranslator(
+                source="auto", target=target_language
+            ).translate(text)
         except Exception as e:
-            logger.error("Translation error: %s", e)
-            return text  # Fallback to original text
+            logger.error("Fallback translation error: %s", e)
+            return text
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ yt-dlp
 ffmpeg-python
 openai-whisper
 googletrans==4.0.0-rc1
+deep-translator
 

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import patch, call
+
+from processor.transcriber import Transcriber
+
+
+class TestTranscriber(unittest.TestCase):
+    """Tests for the Transcriber class."""
+
+    @patch('processor.transcriber.whisper.load_model')
+    @patch('processor.transcriber.torch')
+    def test_mps_fallback_on_error(self, mock_torch, mock_load_model):
+        """Fallback to CPU if MPS load fails."""
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = True
+        mock_torch.backends.mps.is_built.return_value = True
+        mock_load_model.side_effect = [RuntimeError('fail'), object()]
+
+        tr = Transcriber()
+
+        self.assertEqual(tr.device, 'cpu')
+        self.assertEqual(mock_load_model.call_args_list, [
+            call('base', device='mps'),
+            call('base', device='cpu'),
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Detect available CUDA or Apple MPS backends and load Whisper model on that device
- Add class and initializer docstrings for Transcriber
- Retry Google translation and fall back to MyMemory when it fails

## Testing
- `python -m py_compile src/*.py gui/*.py processor/*.py main.py setup_env.py`
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_6898d3514e94832eb5b7c23fc8dfce62