### PR TITLE
Add concurrent model download with progress

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -383,7 +383,8 @@ class TranscribeMonkeyGUI:
                 chunk_paths,
                 language=language,
                 progress_callback=self.update_transcription_progress,
-                stop_event=self.stop_event
+                stop_event=self.stop_event,
+                chunk_length=chunk_length,
             )
 
             if self.stop_event.is_set():

--- a/gui/app.py
+++ b/gui/app.py
@@ -14,7 +14,10 @@ from processor.translator import Translator
 from src.settings import load_settings
 from gui.settings_gui import open_settings as open_settings_window
 from src.file_utils import open_output_folder
-from src.whisper_utils import is_whisper_model_installed
+from src.whisper_utils import (
+    download_whisper_model,
+    is_whisper_model_installed,
+)
 from googletrans import LANGUAGES
 from processor.srt_formatter import correct_srt_format
 from src.logger import get_logger
@@ -34,6 +37,7 @@ class TranscribeMonkeyGUI:
         self.settings = load_settings()
         self.transcriber = None
         self.stop_event = threading.Event()
+        self.model_downloading = False
         self.setup_window()  # Setup window title and icon
         self.create_widgets()
         self.check_system_status()
@@ -206,6 +210,29 @@ class TranscribeMonkeyGUI:
         self.eta_lang_label.config(text=msg)
         self.root.update_idletasks()
 
+    def update_model_download_progress(self, percent, eta):
+        """Update GUI elements during model download."""
+        self.progress['value'] = percent
+        if eta is not None:
+            self.eta_lang_label.config(
+                text=f"ETA: {int(eta)} seconds | Language: N/A"
+            )
+        else:
+            self.eta_lang_label.config(text="ETA: N/A | Language: N/A")
+        self.root.update_idletasks()
+
+    def download_model_with_progress(self, variant):
+        """Download Whisper model and report progress."""
+        def callback(percent, eta):
+            self.update_model_download_progress(percent, eta)
+        try:
+            download_whisper_model(variant, progress_callback=callback)
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to download model:\n{e}")
+            self.stop_event.set()
+        finally:
+            self.model_downloading = False
+
     def get_transcriber(self):
         """Return a cached Transcriber instance for the selected model."""
         model_variant = self.settings.get('model_variant', 'base')
@@ -233,15 +260,30 @@ class TranscribeMonkeyGUI:
 
     def process_youtube(self, url):
         downloader = Downloader(progress_callback=self.update_progress, stop_event=self.stop_event)
+        model_variant = self.settings.get('model_variant', 'base')
+        model_thread = None
+        if not is_whisper_model_installed(model_variant):
+            self.model_downloading = True
+            self.status_label.config(text="Downloading model...")
+            self.eta_lang_label.config(text="ETA: Calculating... | Language: N/A")
+            self.progress['value'] = 0
+            self.root.update_idletasks()
+            model_thread = threading.Thread(
+                target=self.download_model_with_progress,
+                args=(model_variant,),
+                daemon=True,
+            )
+            model_thread.start()
         try:
             audio_path = downloader.download_audio(url)
-            transcriber = self.get_transcriber()
-            audio_path = transcriber.convert_to_audio(
+            audio_path = Transcriber.convert_to_audio(
                 audio_path,
                 normalize_audio=self.settings.get('normalize_audio', True),
                 reduce_noise=self.settings.get('reduce_noise', False),
                 trim_silence=self.settings.get('trim_silence', False),
             )
+            if model_thread:
+                model_thread.join()
             self.status_label.config(text="Download and conversion complete. Starting transcription...")
             self.eta_lang_label.config(text="ETA: Calculating... | Language: N/A")
             self.progress['value'] = 0
@@ -257,18 +299,35 @@ class TranscribeMonkeyGUI:
             self.progress['value'] = 0
             self.eta_lang_label.config(text="ETA: N/A | Language: N/A")
         finally:
+            if model_thread:
+                model_thread.join()
             self.end_task()
 
     def process_file(self, file_path):
-        transcriber = self.get_transcriber()
+        model_variant = self.settings.get('model_variant', 'base')
+        model_thread = None
+        if not is_whisper_model_installed(model_variant):
+            self.model_downloading = True
+            self.status_label.config(text="Downloading model...")
+            self.eta_lang_label.config(text="ETA: Calculating... | Language: N/A")
+            self.progress['value'] = 0
+            self.root.update_idletasks()
+            model_thread = threading.Thread(
+                target=self.download_model_with_progress,
+                args=(model_variant,),
+                daemon=True,
+            )
+            model_thread.start()
         try:
             # Convert to optimal format (16 kHz mono WAV)
-            audio_path = transcriber.convert_to_audio(
+            audio_path = Transcriber.convert_to_audio(
                 file_path,
                 normalize_audio=self.settings.get('normalize_audio', True),
                 reduce_noise=self.settings.get('reduce_noise', False),
                 trim_silence=self.settings.get('trim_silence', False),
             )
+            if model_thread:
+                model_thread.join()
             self.status_label.config(text="Conversion complete. Starting transcription...")
             self.eta_lang_label.config(text="ETA: Calculating... | Language: N/A")
             self.progress['value'] = 0
@@ -284,6 +343,8 @@ class TranscribeMonkeyGUI:
             self.progress['value'] = 0
             self.eta_lang_label.config(text="ETA: N/A | Language: N/A")
         finally:
+            if model_thread:
+                model_thread.join()
             self.end_task()
 
     def transcribe_audio(self, audio_path, base_name):
@@ -427,7 +488,7 @@ class TranscribeMonkeyGUI:
         
         :param d: Dictionary containing download status information.
         """
-        if self.stop_event.is_set():
+        if self.stop_event.is_set() or self.model_downloading:
             return
         if d['status'] == 'downloading':
             total_bytes = d.get('total_bytes') or d.get('total_bytes_estimate')

--- a/processor/transcriber.py
+++ b/processor/transcriber.py
@@ -193,8 +193,8 @@ class Transcriber:
 
         return transcripts, detected_language
 
+    @staticmethod
     def convert_to_audio(
-        self,
         file_path,
         out_dir='downloads',
         *,

--- a/processor/transcriber.py
+++ b/processor/transcriber.py
@@ -132,9 +132,15 @@ class Transcriber:
 
         return chunk_paths
 
-    def transcribe_chunks(self, chunk_paths, language=None,
-                          progress_callback=None, stop_event=None):
-        """Transcribe a list of audio chunks.
+    def transcribe_chunks(
+        self,
+        chunk_paths,
+        language=None,
+        progress_callback=None,
+        stop_event=None,
+        chunk_length=15,
+    ):
+        """Transcribe a list of audio chunks and merge timestamps.
 
         Parameters
         ----------
@@ -146,11 +152,13 @@ class Transcriber:
             Called with ``(percent, idx, total, stage)`` to report progress.
         stop_event : threading.Event | None, optional
             Allows canceling the process mid-way.
+        chunk_length : int | float, optional
+            Length in seconds of each chunk; used to offset timestamps.
 
         Returns
         -------
         tuple[list[dict], str | None]
-            Transcription segments and detected language code.
+            Transcription segments with absolute timestamps and detected language code.
         """
         transcripts = []
         detected_language = None
@@ -165,6 +173,10 @@ class Transcriber:
                 # Transcribe the chunk
                 result = self.model.transcribe(chunk, language=language_param)
                 segments = result.get('segments', [])
+                offset = idx * chunk_length
+                for segment in segments:
+                    segment['start'] += offset
+                    segment['end'] += offset
                 transcripts.extend(segments)
 
                 # Detect language after the first chunk if automatic

--- a/src/whisper_utils.py
+++ b/src/whisper_utils.py
@@ -1,11 +1,66 @@
 """Whisper model utilities.
 
-Provide helpers related to local Whisper model availability."""
+Provide helpers for checking and downloading Whisper models."""
 
 from pathlib import Path
+from typing import Callable, Optional
+import hashlib
+import time
+import urllib.request
+import whisper
 
 
 def is_whisper_model_installed(variant: str) -> bool:
-    """Return True if the specified Whisper model file exists locally."""
+    """Return ``True`` if the specified Whisper model file exists locally."""
     cache_dir = Path.home() / ".cache" / "whisper"
     return (cache_dir / f"{variant}.pt").is_file()
+
+
+def download_whisper_model(
+    variant: str,
+    progress_callback: Optional[Callable[[float, Optional[float]], None]] = None,
+) -> None:
+    """Download a Whisper model with optional progress reporting.
+
+    Parameters
+    ----------
+    variant : str
+        Name of the Whisper model variant, e.g. ``"base"``.
+    progress_callback : Callable[[float, float | None], None], optional
+        Callback receiving the download percentage and ETA in seconds.
+    """
+
+    url = whisper._MODELS.get(variant)
+    if not url:
+        raise ValueError(f"Unknown Whisper model variant: {variant}")
+
+    cache_dir = Path.home() / ".cache" / "whisper"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    target_path = cache_dir / Path(url).name
+
+    if target_path.exists():
+        return
+
+    expected_sha256 = url.split("/")[-2]
+
+    with urllib.request.urlopen(url) as source, open(target_path, "wb") as output:
+        total = int(source.info().get("Content-Length", 0))
+        downloaded = 0
+        start_time = time.time()
+        while True:
+            chunk = source.read(8192)
+            if not chunk:
+                break
+            output.write(chunk)
+            downloaded += len(chunk)
+            if progress_callback and total:
+                percent = downloaded / total * 100
+                elapsed = time.time() - start_time
+                rate = downloaded / elapsed if elapsed else 0
+                eta = (total - downloaded) / rate if rate else None
+                progress_callback(percent, eta)
+
+    model_bytes = target_path.read_bytes()
+    if hashlib.sha256(model_bytes).hexdigest() != expected_sha256:
+        target_path.unlink(missing_ok=True)
+        raise RuntimeError("Model download checksum mismatch")

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,7 +1,7 @@
 """Tests for the Transcriber class."""
 
 import unittest
-from unittest.mock import patch, call
+from unittest.mock import patch, call, Mock
 
 from processor.transcriber import Transcriber
 
@@ -25,6 +25,32 @@ class TestTranscriber(unittest.TestCase):
             call('base', device='mps'),
             call('base', device='cpu'),
         ])
+
+    @patch('processor.transcriber.whisper.load_model')
+    @patch('processor.transcriber.torch')
+    def test_transcribe_chunks_offsets_timestamps(self, mock_torch, mock_load_model):
+        """Offset chunk timestamps so subtitles align with the original audio."""
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = False
+
+        mock_model = Mock()
+        mock_model.transcribe.side_effect = [
+            {'segments': [{'start': 0, 'end': 5, 'text': 'Hello'}], 'language': 'en'},
+            {'segments': [{'start': 0, 'end': 4, 'text': 'World'}]},
+        ]
+        mock_load_model.return_value = mock_model
+
+        tr = Transcriber()
+
+        segments, detected = tr.transcribe_chunks(
+            ['chunk0.mp3', 'chunk1.mp3'],
+            chunk_length=15,
+        )
+
+        self.assertEqual(detected, 'en')
+        self.assertEqual(segments[0]['start'], 0)
+        self.assertEqual(segments[1]['start'], 15)
+        self.assertEqual(segments[1]['end'], 19)
 
 
 if __name__ == '__main__':

--- a/tests/test_whisper_utils.py
+++ b/tests/test_whisper_utils.py
@@ -1,0 +1,65 @@
+"""Tests for Whisper model utility functions."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import tempfile
+
+from src import whisper_utils
+
+
+class TestWhisperUtils(unittest.TestCase):
+    """Validate model download logic and installation checks."""
+
+    @patch("src.whisper_utils.urllib.request.urlopen")
+    @patch("src.whisper_utils.Path.home")
+    @patch.object(whisper_utils, "whisper")
+    def test_download_whisper_model_with_progress(self, mock_whisper, mock_home, mock_urlopen):
+        """Model download writes file and reports progress."""
+        # Prepare temporary directory to act as cache
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_home.return_value = Path(tmpdir)
+
+            # Configure model URL with embedded SHA256
+            data = b"testdata"
+            sha256 = "810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50"
+            url = f"https://host/{sha256}/model.bin"
+            mock_whisper._MODELS = {"dummy": url}
+
+            # Mock HTTP response
+            resp = MagicMock()
+            resp.read = MagicMock(side_effect=[data, b""])
+            resp.__enter__.return_value = resp
+            resp.info.return_value = {"Content-Length": str(len(data))}
+            mock_urlopen.return_value = resp
+
+            progress = []
+
+            def cb(percent, eta):
+                progress.append(percent)
+
+            whisper_utils.download_whisper_model("dummy", progress_callback=cb)
+
+            # File saved
+            cache_file = Path(tmpdir) / ".cache" / "whisper" / "model.bin"
+            self.assertTrue(cache_file.is_file())
+            self.assertEqual(cache_file.read_bytes(), data)
+            # Callback invoked
+            self.assertTrue(progress)
+            self.assertEqual(progress[-1], 100.0)
+
+    def test_is_whisper_model_installed(self):
+        """Detect existing model files in cache."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir) / ".cache" / "whisper"
+            cache_dir.mkdir(parents=True)
+            model_file = cache_dir / "small.pt"
+            model_file.write_bytes(b"dummy")
+
+            with patch("src.whisper_utils.Path.home", return_value=Path(tmpdir)):
+                self.assertTrue(whisper_utils.is_whisper_model_installed("small"))
+                self.assertFalse(whisper_utils.is_whisper_model_installed("base"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add utility to download Whisper models with progress callback
- run model download alongside audio preparation and show ETA in GUI
- allow audio conversion without loading the model

## Testing
- `python -m py_compile src/*.py gui/*.py processor/*.py main.py setup_env.py`
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_689c8941df70832e80211842b18f6532